### PR TITLE
Use DOCKER_TAG for MESSAGE_DB_VERSION

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM postgres:latest
-ARG MESSAGE_DB_VERSION=1.2.2
+ARG MESSAGE_DB_VERSION
 
 WORKDIR /usr/src
 ADD https://github.com/message-db/message-db/archive/v${MESSAGE_DB_VERSION}.tar.gz message-db.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docker-message-db
 
-> Docker image for [Message DB](https://github.com/message-db/message-db)
+Docker image for [Message DB](https://github.com/message-db/message-db), built on `postgres:latest`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docker-message-db
 
-> What it says on the tin: a Message DB Docker image for development.
+> Docker image for [Message DB](https://github.com/message-db/message-db)
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,5 @@ services:
       context: .
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
-    expose:
+    ports:
       - '5432'

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build --build-arg MESSAGE_DB_VERSION=$DOCKER_TAG -f $DOCKERFILE_PATH -t $IMAGE_NAME .


### PR DESCRIPTION
![dilbert](https://assets.amuniversal.com/73bbbf606d5c01301d80001dd8b71c47)

This is an attempt to have multiple tags built from the same `Dockerfile` in `#master` by using the `$DOCKER_TAG` to specify which version of Message DB the image includes.  Seems simple enough, but the docs are sketchy, so I'm just winging it right now.